### PR TITLE
Be/refactor: 과외 삭제시 DB 삭제하지 않고 삭제 상태값으로 관리 로직 추가

### DIFF
--- a/server/src/main/java/com/mainproject/server/constant/TutoringStatus.java
+++ b/server/src/main/java/com/mainproject/server/constant/TutoringStatus.java
@@ -6,5 +6,9 @@ public enum TutoringStatus {
     PROGRESS,
     UNCHECK,
     WAIT_FINISH,
-    FINISH
+    FINISH,
+    TUTOR_DELETE,
+    TUTEE_DELETE,
+    ALL_DELETE;
+
 }

--- a/server/src/main/java/com/mainproject/server/tutoring/controller/TutoringController.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/controller/TutoringController.java
@@ -62,17 +62,10 @@ public class TutoringController {
             @PageableDefault(page = 0, size = 10, sort = "tutoringId", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        Page<Tutoring> pageTutoring =
+        Page<TutoringSimpleResponseDto> findAllTutoring =
                 tutoringService.getAllTutoring(params, profileId, pageable);
-        List<Tutoring> tutoringList = pageTutoring.getContent();
-        List<TutoringSimpleResponseDto> tutoringSimpleList =
-                tutoringMapper.tutoringListToTutoringSimpleResponseDtoList(tutoringList);
-        Page<TutoringSimpleResponseDto> page = new PageImpl<>(
-                tutoringSimpleList,
-                pageTutoring.getPageable(),
-                pageTutoring.getTotalElements());
         return new ResponseEntity(
-                PageResponseDto.of(tutoringSimpleList, page),
+                PageResponseDto.of(findAllTutoring.getContent(), findAllTutoring),
                 HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/mainproject/server/tutoring/dto/TutoringQueryDto.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/dto/TutoringQueryDto.java
@@ -1,0 +1,29 @@
+package com.mainproject.server.tutoring.dto;
+
+
+import com.mainproject.server.constant.TutoringStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TutoringQueryDto {
+
+    private Long tutoringId;
+
+    private String tutorName;
+
+    private String tuteeName;
+
+    private String tutoringTitle;
+
+    private TutoringStatus tutoringStatus;
+
+    private LocalDateTime createAt;
+
+    private LocalDateTime updateAt;
+}

--- a/server/src/main/java/com/mainproject/server/tutoring/dto/TutoringSimpleResponseDto.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/dto/TutoringSimpleResponseDto.java
@@ -1,14 +1,14 @@
 package com.mainproject.server.tutoring.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class TutoringSimpleResponseDto {
 
     private Long tutoringId;
@@ -24,4 +24,18 @@ public class TutoringSimpleResponseDto {
     private LocalDateTime createAt;
 
     private LocalDateTime updateAt;
+
+    public TutoringSimpleResponseDto(TutoringQueryDto dto) {
+        this.tutoringId = dto.getTutoringId();
+        this.tutorName = dto.getTutorName();
+        this.tuteeName = dto.getTuteeName();
+        this.tutoringTitle = dto.getTutoringTitle();
+        this.tutoringStatus = dto.getTutoringStatus().name();
+        this.createAt = dto.getCreateAt();
+        this.updateAt = dto.getUpdateAt();
+    }
+
+    public static TutoringSimpleResponseDto of(TutoringQueryDto dto) {
+        return new TutoringSimpleResponseDto(dto);
+    }
 }

--- a/server/src/main/java/com/mainproject/server/tutoring/repository/TutoringRepository.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/repository/TutoringRepository.java
@@ -1,29 +1,29 @@
 package com.mainproject.server.tutoring.repository;
 
 import com.mainproject.server.constant.TutoringStatus;
+import com.mainproject.server.profile.entity.Profile;
+import com.mainproject.server.profile.entity.QProfile;
+import com.mainproject.server.profile.repository.custom.CustomProfileRepository;
+import com.mainproject.server.tutoring.entity.QTutoring;
 import com.mainproject.server.tutoring.entity.Tutoring;
+import com.mainproject.server.tutoring.repository.custom.CustomTutoringRepository;
+import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 
-public interface TutoringRepository extends JpaRepository<Tutoring, Long> {
-    Page<Tutoring> findAllByTutorProfileIdAndTutoringStatusOrTutorProfileIdAndTutoringStatusOrTutorProfileIdAndTutoringStatus(
-            Long tutorProfileIdOne,
-            TutoringStatus tutoringStatusOne,
-            Long tutorProfileIdTwo,
-            TutoringStatus tutoringStatusTwo,
-            Long tutorProfileIdThree,
-            TutoringStatus tutoringStatusThree,
-            Pageable pageable
-    );
+public interface TutoringRepository extends JpaRepository<Tutoring, Long>,
+        CustomTutoringRepository,
+        QuerydslPredicateExecutor<Tutoring>,
+        QuerydslBinderCustomizer<QTutoring> {
 
-    Page<Tutoring> findAllByTuteeProfileIdAndTutoringStatusOrTuteeProfileIdAndTutoringStatusOrTuteeProfileIdAndTutoringStatus(
-            Long tuteeProfileIdOne,
-            TutoringStatus tutoringStatusOne,
-            Long tuteeProfileIdTwo,
-            TutoringStatus tutoringStatusTwo,
-            Long tuteeProfileIdThree,
-            TutoringStatus tutoringStatusThree,
-            Pageable pageable
-    );
+    @Override
+    default void customize(QuerydslBindings bindings, QTutoring root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.latestNoticeBody);
+        bindings.bind(root.latestNoticeBody).as("latestNoticeBody").first(StringExpression::containsIgnoreCase);
+    }
 }

--- a/server/src/main/java/com/mainproject/server/tutoring/repository/custom/CustomTutoringRepository.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/repository/custom/CustomTutoringRepository.java
@@ -1,0 +1,19 @@
+package com.mainproject.server.tutoring.repository.custom;
+
+import com.mainproject.server.constant.TutoringStatus;
+import com.mainproject.server.tutoring.dto.TutoringQueryDto;
+import com.mainproject.server.tutoring.dto.TutoringSimpleResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CustomTutoringRepository {
+
+    Page<TutoringQueryDto> findQueryTutoring(
+            Long profileId,
+            TutoringStatus status,
+            Pageable pageable
+    );
+
+}

--- a/server/src/main/java/com/mainproject/server/tutoring/repository/custom/CustomTutoringRepositoryImpl.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/repository/custom/CustomTutoringRepositoryImpl.java
@@ -1,0 +1,104 @@
+package com.mainproject.server.tutoring.repository.custom;
+
+import com.mainproject.server.constant.ErrorCode;
+import com.mainproject.server.constant.ProfileStatus;
+import com.mainproject.server.constant.TutoringStatus;
+import com.mainproject.server.exception.ServiceLogicException;
+import com.mainproject.server.profile.entity.QProfile;
+import com.mainproject.server.tutoring.dto.TutoringQueryDto;
+import com.mainproject.server.tutoring.entity.QTutoring;
+import com.mainproject.server.tutoring.entity.Tutoring;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+import java.util.Optional;
+
+public class CustomTutoringRepositoryImpl
+        extends QuerydslRepositorySupport implements CustomTutoringRepository {
+
+    public CustomTutoringRepositoryImpl() {
+        super(Tutoring.class);
+    }
+
+    @Override
+    public Page<TutoringQueryDto> findQueryTutoring(
+            Long profileId,
+            TutoringStatus status,
+            Pageable pageable
+    ) {
+
+        ProfileStatus profileStatus = getProfileStatus(profileId);
+
+        QTutoring tutoring = QTutoring.tutoring;
+        JPQLQuery<TutoringQueryDto> query = from(tutoring)
+                .select(
+                        Projections.constructor(
+                                TutoringQueryDto.class,
+                                tutoring.tutoringId,
+                                tutoring.tutor.name,
+                                tutoring.tutee.name,
+                                tutoring.tutoringTitle,
+                                tutoring.tutoringStatus,
+                                tutoring.createAt,
+                                tutoring.updateAt
+                        )
+                );
+
+        if (profileId != null) {
+            query.where(
+                    tutoring.tutor.profileId.eq(profileId)
+                            .or(tutoring.tutee.profileId.eq(profileId))
+            );
+        }
+        if (profileStatus.equals(ProfileStatus.TUTOR)) {
+            if (status.equals(TutoringStatus.FINISH)) {
+                query.where(
+                        tutoring.tutoringStatus.eq(TutoringStatus.TUTEE_DELETE)
+                                .or(tutoring.tutoringStatus.eq(TutoringStatus.FINISH))
+                );
+            } else {
+                query.where(
+                        tutoring.tutoringStatus.eq(TutoringStatus.TUTEE_DELETE)
+                                .or(tutoring.tutoringStatus.eq(TutoringStatus.PROGRESS))
+                                .or(tutoring.tutoringStatus.eq(TutoringStatus.UNCHECK))
+                                .or(tutoring.tutoringStatus.eq(TutoringStatus.WAIT_FINISH))
+                );
+            }
+        } else {
+            if (status.equals(TutoringStatus.FINISH)) {
+                query.where(
+                        tutoring.tutoringStatus.eq(TutoringStatus.TUTOR_DELETE)
+                                .or(tutoring.tutoringStatus.eq(TutoringStatus.FINISH))
+                );
+            } else {
+                query.where(
+                        tutoring.tutoringStatus.eq(TutoringStatus.TUTOR_DELETE)
+                                .or(tutoring.tutoringStatus.eq(TutoringStatus.PROGRESS))
+                                .or(tutoring.tutoringStatus.eq(TutoringStatus.UNCHECK))
+                                .or(tutoring.tutoringStatus.eq(TutoringStatus.WAIT_FINISH))
+                );
+            }
+        }
+        List<TutoringQueryDto> tutoringList = Optional.ofNullable(getQuerydsl())
+                .orElseThrow(() -> new ServiceLogicException(
+                        ErrorCode.DATA_ACCESS_ERROR))
+                .applyPagination(pageable, query)
+                .fetch();
+        return new PageImpl<>(tutoringList, pageable, query.fetchCount());
+    }
+
+    private ProfileStatus getProfileStatus(Long profileId) {
+        QProfile profile = QProfile.profile;
+        return Optional.ofNullable(
+                        from(profile)
+                                .select(profile.profileStatus)
+                                .where(profile.profileId.eq(profileId))
+                                .fetchFirst())
+                .orElseThrow(() -> new ServiceLogicException(ErrorCode.PROFILE_NOT_FOUND));
+    }
+}

--- a/server/src/main/java/com/mainproject/server/tutoring/service/TutoringService.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/service/TutoringService.java
@@ -100,12 +100,17 @@ public class TutoringService {
                 .ifPresent(findTutoring::setTutoringTitle);
         TutoringStatus tutoringStatus = tutoring.getTutoringStatus();
         if (tutoringStatus != null &&
-                (tutoringStatus.equals(TutoringStatus.WAIT_FINISH) ||
+                (tutoringStatus.equals(TutoringStatus.PROGRESS) ||
+                        tutoringStatus.equals(TutoringStatus.WAIT_FINISH) ||
                         tutoringStatus.equals(TutoringStatus.UNCHECK) ||
-                        tutoringStatus.equals(TutoringStatus.PROGRESS))
+                        tutoringStatus.equals(TutoringStatus.TUTOR_DELETE) ||
+                        tutoringStatus.equals(TutoringStatus.TUTEE_DELETE))
         ) {
-            Optional.of(tutoringStatus)
-                    .ifPresent(findTutoring::setTutoringStatus);
+            if (findTutoring.getTutoringStatus().name().contains("DELETE")) {
+                findTutoring.setTutoringStatus(TutoringStatus.ALL_DELETE);
+            } else {
+                findTutoring.setTutoringStatus(tutoringStatus);
+            }
         } else {
             throw new ServiceLogicException(ErrorCode.WRONG_STATUS_PROPERTY);
         }

--- a/server/src/main/java/com/mainproject/server/tutoring/service/TutoringService.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/service/TutoringService.java
@@ -11,17 +11,23 @@ import com.mainproject.server.message.service.MessageService;
 import com.mainproject.server.profile.entity.Profile;
 import com.mainproject.server.profile.service.ProfileService;
 import com.mainproject.server.tutoring.dto.TutoringDto;
+import com.mainproject.server.tutoring.dto.TutoringQueryDto;
+import com.mainproject.server.tutoring.dto.TutoringSimpleResponseDto;
 import com.mainproject.server.tutoring.entity.Tutoring;
 import com.mainproject.server.tutoring.repository.TutoringRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Transactional
 @Service
@@ -47,7 +53,7 @@ public class TutoringService {
         return save;
     }
 
-    public Page<Tutoring> getAllTutoring(
+    public Page<TutoringSimpleResponseDto> getAllTutoring(
             Map<String, String> params,
             Long profileId,
             Pageable pageable
@@ -55,39 +61,16 @@ public class TutoringService {
         try {
             if (params.isEmpty())
                 throw new ServiceLogicException(ErrorCode.NOT_NULL_WRONG_PROFILE_STATUS_PROPERTY);
-            String get = params.get("get");
-            ProfileStatus profileStatus = profileService
-                    .verifiedProfileById(profileId)
-                    .getProfileStatus();
-            if (TutoringStatus.valueOf(get).equals(TutoringStatus.FINISH)) {
-                params.put("check", TutoringStatus.FINISH.name());
-                params.put("checkTwo", TutoringStatus.FINISH.name());
-            } else if (TutoringStatus.valueOf(get).equals(TutoringStatus.PROGRESS)) {
-                params.put("check", TutoringStatus.UNCHECK.name());
-                params.put("checkTwo", TutoringStatus.WAIT_FINISH.name());
-            }
-            // Todo 쿼리 메소드가 불필요하게 길다. QueryDsl 이용하여 쿼리 구현 리팩토링
-            if (profileStatus.equals(ProfileStatus.TUTEE)) {
-                return tutoringRepository
-                        .findAllByTuteeProfileIdAndTutoringStatusOrTuteeProfileIdAndTutoringStatusOrTuteeProfileIdAndTutoringStatus(
-                                profileId,
-                                TutoringStatus.valueOf(get),
-                                profileId,
-                                TutoringStatus.valueOf(params.get("check")),
-                                profileId,
-                                TutoringStatus.valueOf(params.get("checkTwo")),
-                                pageable);
-            } else {
-                return tutoringRepository
-                        .findAllByTutorProfileIdAndTutoringStatusOrTutorProfileIdAndTutoringStatusOrTutorProfileIdAndTutoringStatus(
-                                profileId,
-                                TutoringStatus.valueOf(get),
-                                profileId,
-                                TutoringStatus.valueOf(params.get("check")),
-                                profileId,
-                                TutoringStatus.valueOf(params.get("checkTwo")),
-                                pageable);
-            }
+
+            Page<TutoringQueryDto> dto = tutoringRepository
+                    .findQueryTutoring(profileId, TutoringStatus.valueOf(params.get("get")), pageable);
+
+            List<TutoringSimpleResponseDto> list = dto.getContent()
+                            .stream()
+                            .map(TutoringSimpleResponseDto::of)
+                            .collect(Collectors.toList());
+
+            return new PageImpl<>(list, dto.getPageable(), dto.getTotalElements());
         } catch (IllegalArgumentException e) {
             throw new ServiceLogicException(ErrorCode.NOT_NULL_WRONG_PROFILE_STATUS_PROPERTY);
         }

--- a/server/src/main/java/com/mainproject/server/tutoring/service/TutoringService.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/service/TutoringService.java
@@ -66,9 +66,9 @@ public class TutoringService {
                     .findQueryTutoring(profileId, TutoringStatus.valueOf(params.get("get")), pageable);
 
             List<TutoringSimpleResponseDto> list = dto.getContent()
-                            .stream()
-                            .map(TutoringSimpleResponseDto::of)
-                            .collect(Collectors.toList());
+                    .stream()
+                    .map(TutoringSimpleResponseDto::of)
+                    .collect(Collectors.toList());
 
             return new PageImpl<>(list, dto.getPageable(), dto.getTotalElements());
         } catch (IllegalArgumentException e) {
@@ -99,13 +99,14 @@ public class TutoringService {
         Optional.ofNullable(tutoring.getTutoringTitle())
                 .ifPresent(findTutoring::setTutoringTitle);
         TutoringStatus tutoringStatus = tutoring.getTutoringStatus();
-        if (tutoringStatus != null &&
-                (tutoringStatus.equals(TutoringStatus.PROGRESS) ||
+        if (tutoringStatus != null && (
+                        tutoringStatus.equals(TutoringStatus.PROGRESS) ||
                         tutoringStatus.equals(TutoringStatus.WAIT_FINISH) ||
+                        tutoringStatus.equals(TutoringStatus.FINISH) ||
                         tutoringStatus.equals(TutoringStatus.UNCHECK) ||
                         tutoringStatus.equals(TutoringStatus.TUTOR_DELETE) ||
-                        tutoringStatus.equals(TutoringStatus.TUTEE_DELETE))
-        ) {
+                        tutoringStatus.equals(TutoringStatus.TUTEE_DELETE)
+        )) {
             if (findTutoring.getTutoringStatus().name().contains("DELETE")) {
                 findTutoring.setTutoringStatus(TutoringStatus.ALL_DELETE);
             } else {

--- a/server/src/test/java/com/mainproject/server/tutoring/controller/TutoringControllerTest.java
+++ b/server/src/test/java/com/mainproject/server/tutoring/controller/TutoringControllerTest.java
@@ -252,7 +252,7 @@ class TutoringControllerTest {
                                                 fieldWithPath("data").type(JsonFieldType.OBJECT).description("결과 데이터"),
                                                 fieldWithPath("data.tutoringId").type(JsonFieldType.NUMBER).description("과외 식별자"),
                                                 fieldWithPath("data.tutoringTitle").type(JsonFieldType.STRING).description("튜터 타이틀"),
-                                                fieldWithPath("data.tutoringStatus").type(JsonFieldType.STRING).description("과외 상태 TUTEE_WAITING/TUTOR_WAITING/PROGRESS/UNCHECK/WAIT_FINISH/FINISH"),
+                                                fieldWithPath("data.tutoringStatus").type(JsonFieldType.STRING).description("과외 상태 PROGRESS/WAIT_FINISH/TUTOR_DELETE/TUTEE_DELETE"),
                                                 fieldWithPath("data.latestNoticeId").type(JsonFieldType.NUMBER).description("마지막 공지 식별자"),
                                                 fieldWithPath("data.latestNoticeBody").type(JsonFieldType.STRING).description("마지막 공지 내용"),
                                                 fieldWithPath("data.tuteeId").type(JsonFieldType.NUMBER).description("튜티 식별자"),

--- a/server/src/test/java/com/mainproject/server/tutoring/controller/TutoringControllerTest.java
+++ b/server/src/test/java/com/mainproject/server/tutoring/controller/TutoringControllerTest.java
@@ -163,17 +163,15 @@ class TutoringControllerTest {
         // Given
         Long profileId = 1L;
         Pageable pageable = PageRequest.of(1, 10);
-        Page<Tutoring> pageProfile =
-                new PageImpl<>(List.of(
-                        new Tutoring(),
-                        new Tutoring()),
-                        pageable, 2);
         TutoringSimpleResponseDto tutoringSimpleResponse =
                 ResponseStubData.createTutoringSimpleResponse();
+        Page<TutoringSimpleResponseDto> pageProfile =
+                new PageImpl<>(List.of(
+                        tutoringSimpleResponse,
+                        tutoringSimpleResponse),
+                        pageable, 2);
         given(tutoringService.getAllTutoring(anyMap(), anyLong(), any(Pageable.class)))
                 .willReturn(pageProfile);
-        given(tutoringMapper.tutoringListToTutoringSimpleResponseDtoList(anyList()))
-                .willReturn(List.of(tutoringSimpleResponse, tutoringSimpleResponse));
         // When
         RequestBuilder result = RestDocumentationRequestBuilders
                 .get("/tutoring/{profileId}?page=0", profileId)

--- a/server/src/test/java/com/mainproject/server/tutoring/service/TutoringServiceTest.java
+++ b/server/src/test/java/com/mainproject/server/tutoring/service/TutoringServiceTest.java
@@ -10,6 +10,8 @@ import com.mainproject.server.message.service.MessageService;
 import com.mainproject.server.profile.entity.Profile;
 import com.mainproject.server.profile.service.ProfileService;
 import com.mainproject.server.tutoring.dto.TutoringDto;
+import com.mainproject.server.tutoring.dto.TutoringQueryDto;
+import com.mainproject.server.tutoring.dto.TutoringSimpleResponseDto;
 import com.mainproject.server.tutoring.entity.Tutoring;
 import com.mainproject.server.tutoring.repository.TutoringRepository;
 import com.mainproject.server.utils.StubData;
@@ -49,72 +51,45 @@ class TutoringServiceTest {
     private TutoringService tutoringService;
 
     @Test
-    @DisplayName("특정 프로필 과외 리스트 - TUTEE 경우")
-    void getTuteeAllTutoring() {
+    @DisplayName("특정 프로필 과외 리스트 - 동작 TEST")
+    void getAllTutoring() {
         //given
-        Map<String, String> param1 = new HashMap<>();
-        param1.put("get", "PROGRESS");
+        Map<String, String> param = new HashMap<>();
+        param.put("get", "PROGRESS");
         Pageable page = PageRequest.of(1,10);
         Long profileId = 1L;
-        Tutoring tutoring1 = new Tutoring();
+        TutoringQueryDto tutoring1 = new TutoringQueryDto();
         tutoring1.setTutoringStatus(TutoringStatus.FINISH);
         List list1 = List.of(tutoring1, tutoring1);
-        Page<Tutoring> result1 = new PageImpl<>(list1, page, list1.size());
-        Profile testProfile = new Profile();
-        testProfile.setProfileStatus(ProfileStatus.TUTEE);
-
-        given(profileService.verifiedProfileById(anyLong())).willReturn(testProfile);
-        given(tutoringRepository.findAllByTuteeProfileIdAndTutoringStatusOrTuteeProfileIdAndTutoringStatusOrTuteeProfileIdAndTutoringStatus(
-                anyLong(),
-                any(TutoringStatus.class),
-                anyLong(),
-                any(TutoringStatus.class),
+        Page<TutoringQueryDto> result1 = new PageImpl<>(list1, page, list1.size());
+        given(tutoringRepository.findQueryTutoring(
                 anyLong(),
                 any(TutoringStatus.class),
                 any(Pageable.class)
         )).willReturn(result1);
-
-
         //when
-        Page<Tutoring> testResult1 = tutoringService.getAllTutoring(param1, profileId, page);
-
+        Page<TutoringSimpleResponseDto> testResult =
+                tutoringService.getAllTutoring(param, profileId, page);
         //then
-        assertThat(testResult1.getContent().get(0).getTutoringStatus()).isEqualTo(TutoringStatus.FINISH);
+        assertThat(testResult.getContent().get(0).getTutoringStatus())
+                .isEqualTo(TutoringStatus.FINISH.name());
 
     }
 
     @Test
-    @DisplayName("특정 프로필 과외 리스트 - TUTOR 경우")
-    void getTutorAllTutoring() {
-
-        //given
-        Map<String, String> param2 = new HashMap<>();
-        param2.put("get", "PROGRESS");
-        Pageable page = PageRequest.of(1,10);
+    @DisplayName("특정 프로필 과외 리스트 - Parameter Input 예외 TEST")
+    void getAllTutoringThrowServiceLogicException() {
+        // Given
         Long profileId = 1L;
-        Tutoring tutoring2 = new Tutoring();
-        tutoring2.setTutoringStatus(TutoringStatus.UNCHECK);
-        List list2 = List.of(tutoring2, tutoring2);
-        Page<Tutoring> result2 = new PageImpl<>(list2, page, list2.size());
-        Profile testProfile = new Profile();
-        testProfile.setProfileStatus(ProfileStatus.TUTOR);
-
-        given(profileService.verifiedProfileById(anyLong())).willReturn(testProfile);
-        given(tutoringRepository.findAllByTutorProfileIdAndTutoringStatusOrTutorProfileIdAndTutoringStatusOrTutorProfileIdAndTutoringStatus(
-                anyLong(),
-                any(TutoringStatus.class),
-                anyLong(),
-                any(TutoringStatus.class),
-                anyLong(),
-                any(TutoringStatus.class),
-                any(Pageable.class)
-        )).willReturn(result2);
-
-        //when
-        Page<Tutoring> testResult2 = tutoringService.getAllTutoring(param2, profileId, page);
-
-        //then
-        assertThat(testResult2.getContent().get(0).getTutoringStatus()).isEqualTo(TutoringStatus.UNCHECK);
+        Pageable page = PageRequest.of(1,10);
+        Map<String, String> param = new HashMap<>();
+        // When
+        Throwable throwable = catchThrowable(
+                () -> tutoringService.getAllTutoring(param, profileId, page)
+        );
+        // Then
+        assertThat(throwable).isInstanceOf(ServiceLogicException.class)
+                .hasMessageContaining(ErrorCode.NOT_NULL_WRONG_PROFILE_STATUS_PROPERTY.getMessage());
     }
 
     @Test


### PR DESCRIPTION
- Tutoring 종료된 과외 삭제 시 데이터 삭제하지 않고 삭제 상태 값으로 관리하도록 로직 추가
- Tutoring 전체 조회 시 종료된 과외 상태값 추가
- 변경 부분 테스트 코드 반영
- Tutoring PATCH 요청시 삭제 상태값 변경 가능하도록 로직 변경
- Tutoring 삭제 상태값 PATCH 요청 시 유효성 검증 로직 추가

Issue #240 