### PR TITLE
fix: 과외 리스트 조회시 상태값별 분기 조회 오류 수정

### DIFF
--- a/server/src/main/java/com/mainproject/server/tutoring/repository/custom/CustomTutoringRepositoryImpl.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/repository/custom/CustomTutoringRepositoryImpl.java
@@ -63,8 +63,7 @@ public class CustomTutoringRepositoryImpl
                 );
             } else {
                 query.where(
-                        tutoring.tutoringStatus.eq(TutoringStatus.TUTEE_DELETE)
-                                .or(tutoring.tutoringStatus.eq(TutoringStatus.PROGRESS))
+                        tutoring.tutoringStatus.eq(TutoringStatus.PROGRESS)
                                 .or(tutoring.tutoringStatus.eq(TutoringStatus.UNCHECK))
                                 .or(tutoring.tutoringStatus.eq(TutoringStatus.WAIT_FINISH))
                 );
@@ -77,8 +76,7 @@ public class CustomTutoringRepositoryImpl
                 );
             } else {
                 query.where(
-                        tutoring.tutoringStatus.eq(TutoringStatus.TUTOR_DELETE)
-                                .or(tutoring.tutoringStatus.eq(TutoringStatus.PROGRESS))
+                        tutoring.tutoringStatus.eq(TutoringStatus.PROGRESS)
                                 .or(tutoring.tutoringStatus.eq(TutoringStatus.UNCHECK))
                                 .or(tutoring.tutoringStatus.eq(TutoringStatus.WAIT_FINISH))
                 );


### PR DESCRIPTION
- TUTOR_DELETE / TUTEE_DELETE 상태값은 FINISH 이후 상태값이므로 PROGRESS 조회 할때 빠져야됨