### PR TITLE
Be/refactor: 매칭 요청 취소, 문의 취소 유효성 검증 추가 및 변경

### DIFF
--- a/server/src/main/java/com/mainproject/server/message/service/MessageService.java
+++ b/server/src/main/java/com/mainproject/server/message/service/MessageService.java
@@ -117,22 +117,15 @@ public class MessageService {
 
     public void deleteMessageRoom(Long messageRoomId) {
         MessageRoom messageRoom = verifiedMessageRoom(messageRoomId);
-        if (messageRoom.getTutoringId() != null) {
-            Long tutoringId = messageRoom.getTutoringId();
-            Tutoring tutoring = tutoringRepository.findById(tutoringId)
-                    .orElseThrow(() -> new ServiceLogicException(ErrorCode.NOT_FOUND));
-            if (tutoring.getTutoringStatus().equals(TutoringStatus.TUTOR_WAITING) ||
-                    tutoring.getTutoringStatus().equals(TutoringStatus.TUTEE_WAITING)
-            ) {
-                tutoringRepository.delete(tutoring);
-            } else {
-                throw new ServiceLogicException(ErrorCode.PROGRESS_TUTORING_BAD_REQUEST);
-            }
+        if (messageRoom.getTutoringId() == null) {
+            messageRepository.deleteAllById(messageRoom.getMessages()
+                    .stream().map(Message::getMessageId)
+                    .collect(Collectors.toList()));
+            messageRoomRepository.deleteById(messageRoomId);
+        } else {
+            throw new ServiceLogicException(ErrorCode.PROGRESS_TUTORING_BAD_REQUEST);
         }
-        messageRepository.deleteAllById(messageRoom.getMessages()
-                .stream().map(Message::getMessageId)
-                .collect(Collectors.toList()));
-        messageRoomRepository.deleteById(messageRoomId);
+
     }
 
     public void sendTutoringRequestMessage(

--- a/server/src/main/java/com/mainproject/server/tutoring/service/TutoringService.java
+++ b/server/src/main/java/com/mainproject/server/tutoring/service/TutoringService.java
@@ -119,8 +119,15 @@ public class TutoringService {
     }
 
     public void deleteTutoring(Long tutoringId) {
-        messageService.deleteMessageRoomTutoringId(tutoringId);
-        tutoringRepository.delete(verifiedTutoring(tutoringId));
+        Tutoring tutoring = verifiedTutoring(tutoringId);
+        if (tutoring.getTutoringStatus().equals(TutoringStatus.TUTEE_WAITING) ||
+                tutoring.getTutoringStatus().equals(TutoringStatus.TUTOR_WAITING)
+        ) {
+            messageService.deleteMessageRoomTutoringId(tutoringId);
+            tutoringRepository.delete(tutoring);
+        } else {
+            throw new ServiceLogicException(ErrorCode.TUTORING_STATUS_BAD_REQUEST);
+        }
     }
 
     /* 검증 및 유틸 로직 */


### PR DESCRIPTION
- 매칭 요청 취소 시 TUTOR_WAITING & TUTEE_WAITING일 경우에만 완전 삭제 가능하도록 유효성 검증 추가
- 기존 매칭 중 일때만 메세지 룸 삭제(문의 취소) 가능하도록 하였지만 MessageRoom과 Tutoring의 의존성 조절을 통하여 Tutoring과 연결 관계가 없을때만 삭제 가능하도록 변경


Issue #255 